### PR TITLE
Allow, for now, multiple lexemes in generation.

### DIFF
--- a/generate_lxx.py
+++ b/generate_lxx.py
@@ -16,7 +16,7 @@ NUM_WORDS_IN_LXX = 623693
 def load_lexemes(lxx_data: list[dict], file):
     reader = csv.reader(file, delimiter='\t')
     for idx, row in enumerate(reader):
-        lxx_data[idx]['lexeme'] = row[1]
+        lxx_data[idx]['lexeme'] = [row[1]]
 
 
 def load_versification(lxx_data: list[dict], file):

--- a/generate_opengnt.py
+++ b/generate_opengnt.py
@@ -369,6 +369,14 @@ def convert_line(row: list[str], idx: int) -> dict:
             # Transform the book into a string first.
             book_number = int(helpers.get_row_val(field, row))
             result[field] = interpret_book_code(book_number)
+        elif field == 'lexeme':
+            # There's the possibility of there being multiple "options" for the lexeme. So the lexeme stored on
+            # υδωρ is "υδωρ, υδατος." In the future, it would be beneficial to figure out whether the lexeme is always
+            # the first option. (υδατος not being a lexeme, but a genitive form) But, for now, this problem is here
+            # circumvented by registering them both as lexemes.
+            lexemes = helpers.get_row_val(field, row).split(',')
+            lexemes = [x.strip() for x in lexemes]
+            result[field] = lexemes
         else:
             result[field] = helpers.get_row_val(field, row)
 

--- a/text_query.py
+++ b/text_query.py
@@ -69,8 +69,18 @@ class LexemeQuery(TextQuery):
     def search(self, dataset: list[dict]) -> list[dict[str, str|int]]:
         """Searches for the given lexeme."""
         # Create a sublist of rows with the given lexeme.
+        def matches_lex(row, lex):
+            """True if one of the lexemes is matched."""
+            # Strip the accents in lexeme.
+            stripped = [helpers.strip_accents(x) for x in row['lexeme']]
+
+            for x in stripped:
+                if re.match(lex, x):
+                    return True
+            return False
+
         lexeme_rows = [
-            row for row in dataset if re.match(self.lexeme, helpers.strip_accents(row['lexeme']))]
+            row for row in dataset if matches_lex(row, self.lexeme)]
 
         # Further limit based upon other fields if provided.
         if self.case is not None:


### PR DESCRIPTION
This is kind of a "quick patch" to fix the issue wherein OpenGNT doesn't actually store lexemes in the lexeme field for some words, but rather what may be considered "flashcard forms" -- both the nominative and genitive form. In the future, I want to make a change where of these fields only the lexemes are stored, but I'm unsure yet as to what the format is in OpenGNT, if it's always nominative-genitive, or if there's other weirdness.